### PR TITLE
Fix error in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 PyYAML
 irc<1.0dev
-pytz
+pytz==2013d
 requests
 simplejson


### PR DESCRIPTION
PyTZ now requires you to specifically state which timezone values you would like to use.
