### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+from ubuntu:12.04
+maintainer Nick Stinemates
+
+run apt-get install -y python-setuptools
+run easy_install pip
+volume /logs
+
+add . /bot
+workdir /bot
+
+run pip install -r /bot/requirements.txt
+
+cmd ["python", "bin/bender"]


### PR DESCRIPTION
This patch creates a Dockerfile which allows you to run the bot unmodified inside of a Docker container. It expects logs to be stored in /logs and exposes this as a volume.
