### PR TITLE
Fix hardcoded logfile name

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -14,6 +14,7 @@ standups:
         standup_channel: '#dotcloud-scrum-standup'
         warmup_duration: 60
         speak_limit: 3
+        logfile_name: 'standup'
         send_logs_from:  'standup-list@acme.com'
         send_logs_to:
             - 'standup.list@acme.com'

--- a/lib/archives.py
+++ b/lib/archives.py
@@ -12,7 +12,8 @@ class DiskArchives(object):
 
     def __init__(self, global_config, config):
         self._basepath = os.path.join(os.path.expanduser(global_config['logs']),
-                'standup_archives')
+                config.get('logfile_name'))
+
         self._timezone = None
         self._file = None
 


### PR DESCRIPTION
In lib/archives.py, the name of the logfile cannot be overridden and thus cannot serve multiple plugins / expanded logging usecases.

This simply adds a configuration variable to the `config.yml` file which allows you to control the name of the log.
